### PR TITLE
fix: correct OTP regeneration timing

### DIFF
--- a/backend/controllers/userController.go
+++ b/backend/controllers/userController.go
@@ -177,9 +177,7 @@ func GenerateOTP(c *gin.Context) {
 		helper.Response(c, http.StatusNotFound, "User not found", nil, nil)
 		return
 	}
-	currentTime := time.Now()
-	timeDiff := currentTime.Sub(user.OTPTime)
-	if user.OTP != 0 && timeDiff > time.Duration(constants.OTP_REGENERATION_TIME)*time.Minute {
+	if user.OTP != 0 && time.Since(user.OTPTime) < time.Duration(constants.OTP_REGENERATION_TIME)*time.Minute {
 		helper.Response(
 			c,
 			http.StatusTooManyRequests,
@@ -196,7 +194,7 @@ func GenerateOTP(c *gin.Context) {
 	// 	helper.Response(c, http.StatusInternalServerError, "Failed to send OTP", nil, err)
 	// 	return
 	// }
-	otp := rand.Intn(constants.MAX_OTP_LENGTH-constants.MIN_OTP_LENGTH) + constants.MIN_OTP_LENGTH
+	otp := rand.Intn(constants.MAX_OTP_LENGTH-constants.MIN_OTP_LENGTH+1) + constants.MIN_OTP_LENGTH
 
 	user.OTP = uint(otp)
 	user.OTPTime = time.Now()


### PR DESCRIPTION
## Summary
- fix OTP regeneration check to ensure users wait before requesting new OTP
- allow OTP generation to include maximum value

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688c57165548832786df447fe7376124