### PR TITLE
refactor: centralize auth layout

### DIFF
--- a/frontend/src/app/forgot-password/_component/forgotPassword.tsx
+++ b/frontend/src/app/forgot-password/_component/forgotPassword.tsx
@@ -3,8 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import {LoginBackgroundEffect } from '@/components/BackgroundEffect';
-import FormWrapper  from '@/components/FormWrapper';
+import AuthWrapper from '@/components/AuthWrapper';
 import LoginHeader from '@/components/loginHeader';
 import InputField from '@/components/Fields/InputField';
 import SubmitButton from '@/components/Fields/Button';
@@ -65,13 +64,9 @@ export default function ForgetPasswordComponent() {
     }
     
     return (
-        <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
-        <LoginBackgroundEffect />
-        
-        <div className="w-full max-w-md relative z-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
-            <FormWrapper>
+        <AuthWrapper>
             <LoginHeader />
-            
+
             <form onSubmit={handleSubmit} className="space-y-6">
                 <div className="space-y-4">
                 <InputField
@@ -111,8 +106,6 @@ export default function ForgetPasswordComponent() {
                 </p>
                 </div>
             </form>
-            </FormWrapper>
-        </div>
-        </div>
+        </AuthWrapper>
     )
 }

--- a/frontend/src/app/login/_component/login.tsx
+++ b/frontend/src/app/login/_component/login.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState } from 'react';
 import Link from 'next/link';
-import {LoginBackgroundEffect as BackgroundEffect} from '@/components/BackgroundEffect';
-import FormWrapper  from '@/components/FormWrapper';
+import AuthWrapper from '@/components/AuthWrapper';
 import LoginHeader from '@/components/loginHeader';
 import InputField from '@/components/Fields/InputField';
 import SubmitButton from '@/components/Fields/Button';
@@ -66,13 +65,9 @@ export default function LoginComponent() {
     }
 
     return (
-        <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
-      <BackgroundEffect />
-      
-      <div className="w-full max-w-md relative z-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
-        <FormWrapper>
+        <AuthWrapper>
           <LoginHeader />
-          
+
           <form onSubmit={handleSubmit} className="space-y-6">
             <div className="space-y-4">
               <InputField
@@ -103,9 +98,9 @@ export default function LoginComponent() {
                 Forgot password?
               </Link>
             </div>
-            
+
             <ErrorMessage errors={errors} />
-            
+
             <SubmitButton isLoading={isLoading} loadingText={"logging you in ...,"} submitText={`login in to ${APP_NAME}`}/>
             
             <div className="text-center">
@@ -120,8 +115,6 @@ export default function LoginComponent() {
               </p>
             </div>
           </form>
-        </FormWrapper>
-      </div>
-    </div>
+        </AuthWrapper>
     )
 }

--- a/frontend/src/app/register/_component/register.tsx
+++ b/frontend/src/app/register/_component/register.tsx
@@ -1,8 +1,7 @@
 "use client";
 import React, { useState } from 'react';
 import Link from 'next/link';
-import { LoginBackgroundEffect as BackgroundEffect } from '@/components/BackgroundEffect';
-import FormWrapper from '@/components/FormWrapper';
+import AuthWrapper from '@/components/AuthWrapper';
 import LoginHeader from '@/components/loginHeader';
 import InputField from '@/components/Fields/InputField';
 import SubmitButton from '@/components/Fields/Button';
@@ -69,11 +68,7 @@ const RegisterComponent: React.FC = () => {
     };
 
     return (
-        <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
-            <BackgroundEffect />
-
-            <div className="w-full max-w-md relative z-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
-                <FormWrapper>
+        <AuthWrapper>
                     <LoginHeader />
 
                     <form onSubmit={handleSubmit} className="space-y-6">
@@ -124,9 +119,7 @@ const RegisterComponent: React.FC = () => {
                             </p>
                         </div>
                     </form>
-                </FormWrapper>
-            </div>
-        </div>
+        </AuthWrapper>
     );
 };
 

--- a/frontend/src/app/reset-password/_component/resetPassword.tsx
+++ b/frontend/src/app/reset-password/_component/resetPassword.tsx
@@ -2,9 +2,8 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { LoginBackgroundEffect as BackgroundEffect } from "@/components/BackgroundEffect";
 import { ResetPasswordFormData } from "@/app/reset-password/constant/instances";
-import FormWrapper from "@/components/FormWrapper";
+import AuthWrapper from "@/components/AuthWrapper";
 import LoginHeader from "@/components/loginHeader";
 import InputField from "@/components/Fields/InputField";
 import SubmitButton from "@/components/Fields/Button";
@@ -193,11 +192,7 @@ export default function ResetComponent() {
     }
   };
   return (
-    <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
-      <BackgroundEffect />
-
-      <div className="w-full max-w-md relative z-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
-        <FormWrapper>
+    <AuthWrapper>
           <LoginHeader />
 
           <form onSubmit={handleResetPassword} className="space-y-6">
@@ -322,8 +317,6 @@ export default function ResetComponent() {
               </p>
             </div>
           </form>
-        </FormWrapper>
-      </div>
-    </div>
+    </AuthWrapper>
   );
 }

--- a/frontend/src/components/AuthWrapper.tsx
+++ b/frontend/src/components/AuthWrapper.tsx
@@ -1,0 +1,19 @@
+import { LoginBackgroundEffect } from '@/components/BackgroundEffect';
+import FormWrapper from '@/components/FormWrapper';
+
+interface AuthWrapperProps {
+  children: React.ReactNode;
+}
+
+export default function AuthWrapper({ children }: AuthWrapperProps) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 relative overflow-hidden">
+      <LoginBackgroundEffect />
+      <div className="w-full max-w-md relative z-10 animate-in fade-in slide-in-from-bottom-4 duration-700">
+        <FormWrapper>
+          {children}
+        </FormWrapper>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AuthWrapper` component combining background effect and form container
- refactor auth-related pages to use `AuthWrapper` for consistent styling

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688cb4c1729c8327bc9bdbc090a6262b